### PR TITLE
Make it compatible to Play 2.7

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -1,1 +1,1 @@
-play.crypto.secret = "none"
+play.http.secret.key="QCY?tAnfk?aZ?iwrNwnxIlR6CTf:G3gf:90Latabg@5241AB`R5W:1uDFN];Ik@n"


### PR DESCRIPTION
This make the server compatible with Play 2.7.

Lagom documentation site uses it to run the site locally. Without that fix we can't run it.

The deployed documentation is static and doesn't use that secret.