### PR TITLE
Override Akka plugin dependencies to 2.5.17

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,16 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-uglify" % "2.0.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.0")
+
+val akkaVersion = "2.5.17"
+
+dependencyOverrides ++= Seq(
+  "com.typesafe.akka" %% "akka-actor" % akkaVersion,
+  "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
+  "com.typesafe.akka" %% "akka-cluster-tools" % akkaVersion,
+  "com.typesafe.akka" %% "akka-contrib" % akkaVersion,
+  "com.typesafe.akka" %% "akka-persistence" % akkaVersion,
+  "com.typesafe.akka" %% "akka-protobuf" % akkaVersion,
+  "com.typesafe.akka" %% "akka-remote" % akkaVersion,
+  "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+)


### PR DESCRIPTION
Previously, the build logged warnings about mixed versions of Akka modules.